### PR TITLE
Heroku deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: python example.py

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python example.py
+web: python example.py --github_client_id=${GITHUB_CLIENT_ID} --github_client_secret=${GITHUB_CLIENT_SECRET} --port=${PORT}

--- a/app.json
+++ b/app.json
@@ -1,16 +1,8 @@
 {
   "name": "torngithub",
-  "description": "Demonstrates the torngithub example",
+  "description": "Demonstrates the torngithub example. You will need to create an application at https://github.com/settings/developers, and define environment variables GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET in order to use.",
   "keywords": [
     "tornado", "github", "OAuth"
   ],
   "repository": "https://github.com/jkeylu/torngithub",
-  "env": {
-    "CLIENT_ID": {
-      "description": "The client ID from the application created at https://github.com/settings/developers",
-    },
-    "CLIENT_SECRET": {
-      "description": "The client secret from the application created at https://github.com/settings/developers",
-    }
-  }
 }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,16 @@
+{
+  "name": "torngithub",
+  "description": "Demonstrates the torngithub example",
+  "keywords": [
+    "tornado", "github", "OAuth"
+  ],
+  "repository": "https://github.com/jkeylu/torngithub",
+  "env": {
+    "CLIENT_ID": {
+      "description": "The client ID from the application created at https://github.com/settings/developers",
+    },
+    "CLIENT_SECRET": {
+      "description": "The client secret from the application created at https://github.com/settings/developers",
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pycurl
+tornado

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,7 @@ distutils.core.setup(
     author_email='jkeylu@gmail.com',
     url='https://github.com/jkeylu/torngithub',
     license='http://www.apache.org/licenses/LICENSE-2.0',
-    description='Github authentication for tornado'
+    description='Github authentication for tornado',
+    install_requires=['tornado',
+                      'pycurl'],
 )


### PR DESCRIPTION
Demonstrates deploying torngithub's example to Herkou, as can be seen at http://torngithub.herokuapp.com/. I'm quite content if it is decided that this shouldn't be a part of this repository. I just wanted to share it here.